### PR TITLE
Remove duplicated function list in log file

### DIFF
--- a/modules/actions/design_function.py
+++ b/modules/actions/design_function.py
@@ -21,5 +21,5 @@ class DesignFunction(Action):
 
             functions_name_and_content.append({"name": function_name[0], "content": function})
         self._context.function_list = functions_name_and_content
-        self._context.log.format_message(f"{code}", "response")
+        # self._context.log.format_message(f"{code}", "response")
         return str(functions_name_and_content)


### PR DESCRIPTION
#106
在log文件中，function list重复出现。因此考虑将第二个function list删去。
使得整个log.md文件中保持“prompt--response--prompt--response--...”的书写逻辑。